### PR TITLE
Fix minor typo in reference sheet

### DIFF
--- a/Final_Reference_Sheet.csv
+++ b/Final_Reference_Sheet.csv
@@ -32,7 +32,7 @@ Hrushikesh Surabhi,IT/PT/6M ,Monday - Friday 12pm - 5pm
 Nathaniel Yang,IT/FT/6M - Training,Monday -  Friday 8am - 5pm
 Akhil Rachakonda,IT/FT/3M - Training,Monday -  Friday 8am - 5pm
 Sanjana Holla,IT/PT/3M - Training,"Monday and Wednesday 8am - 12pm and 3pm - 5pm, Tuesday and Thursday 8am - 11am and 3pm - 5pm"
-Chengming (Tommy) Li,DM/PT/6M,"Monday 8am - 11am; 3pm -5pm, Tuesday 8am - 11pm; 3pm - 5pm, Wednesday 8am - 10pm, Thursady 8am - 11pm; 3pm - 5pm, Friday 8am - 10am; 3pm - 5pm"
+Chengming (Tommy) Li,DM/PT/6M,"Monday 8am - 11am; 3pm -5pm, Tuesday 8am - 11pm; 3pm - 5pm, Wednesday 8am - 10pm, Thursday 8am - 11pm; 3pm - 5pm, Friday 8am - 10am; 3pm - 5pm"
 Amy Lin,DM/PT/6M,Monday - Friday 8am - 12pm  
 Manaswi Thati,DM/PT/3M,Monday - Friday 8am - 2pm
 Carsen Currie,DM/PT/6M,"Tuesday 8am-4pm, Wednesday 8am-12pm, Thursday 8am-4pm"


### PR DESCRIPTION
## Summary
- correct `Thursady` to `Thursday` in Chengming Li's schedule

## Testing
- `grep -n "Chengming" -n Final_Reference_Sheet.csv`

------
https://chatgpt.com/codex/tasks/task_e_684a1144ca108323806e7830062c9dd6