### PR TITLE
Fix download_file HTTP error handling

### DIFF
--- a/graph_timesheet_processor.py
+++ b/graph_timesheet_processor.py
@@ -39,6 +39,7 @@ def list_files(folder_id):
 def download_file(item_id, filename):
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}/content"
     response = requests.get(url, headers=headers)
+    response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(response.content)
 


### PR DESCRIPTION
## Summary
- call `raise_for_status()` before writing file contents

## Testing
- `python -m py_compile graph_timesheet_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_684a113d6ecc8323946fca216dc74991