### PR TITLE
Fix missing error handling in file download

### DIFF
--- a/graph_timesheet_processor.py
+++ b/graph_timesheet_processor.py
@@ -39,6 +39,7 @@ def list_files(folder_id):
 def download_file(item_id, filename):
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}/content"
     response = requests.get(url, headers=headers)
+    response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(response.content)
 


### PR DESCRIPTION
## Summary
- prevent saving an error response when downloading files

## Testing
- `python -m py_compile graph_timesheet_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_684a10bde55c8323931054c22c1cc056